### PR TITLE
feat: Add dark mode support with theme toggle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "lucide-react": "^0.408.0",
         "next": "14.2.5",
         "next-mdx-remote": "^5.0.0",
+        "next-themes": "^0.4.6",
         "react": "^18",
         "react-dom": "^18",
         "react-markdown": "^9.0.1",
@@ -6164,6 +6165,16 @@
       },
       "peerDependencies": {
         "react": ">=16"
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "lucide-react": "^0.408.0",
     "next": "14.2.5",
     "next-mdx-remote": "^5.0.0",
+    "next-themes": "^0.4.6",
     "react": "^18",
     "react-dom": "^18",
     "react-markdown": "^9.0.1",

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -5,7 +5,7 @@ const subTitleProperty = 'text-xl mb-3 font-semibold';
 const About = async () => {
     return (
         <>
-            <div className="p-2 min-h-[75vh] text-base font-normal text-gray-800 leading-7">
+            <div className="p-2 min-h-[75vh] text-base font-normal text-gray-800 dark:text-gray-200 leading-7">
                 <div className="mb-5 text-2xl font-semibold">
                     안녕하세요{' '}
                     <span className="text-yellow-500 hover:text-yellow-600 transition-colors duration-300">

--- a/src/app/blog/TeamPage.module.css
+++ b/src/app/blog/TeamPage.module.css
@@ -4,7 +4,12 @@
   margin: 0 auto;
   padding: 0 2em 0 2em;
   border-left: 1.5px solid #e1e1e1;
-  box-shadow: 10px 4px 8px rgba(0, 0, 0, 0.1); /* 그림자 추가 */
+  box-shadow: 10px 4px 8px rgba(0, 0, 0, 0.1);
+}
+
+:global(.dark) .container {
+  border-left-color: #374151;
+  box-shadow: 10px 4px 8px rgba(0, 0, 0, 0.3);
 }
 
 .main {
@@ -26,6 +31,10 @@
   margin-top: 2em;
   margin-bottom: 40px;
   border-bottom: 1px solid #cbd5e0;
+}
+
+:global(.dark) .header {
+  border-bottom-color: #4a5568;
 }
 
 .headerTitle {
@@ -118,6 +127,10 @@
 .footer {
   border-top: 1px solid #cbd5e0;
 }
+
+:global(.dark) .footer {
+  border-top-color: #4a5568;
+}
 .bottom {
   margin: 0.75em 0 0.75em 0;
 }
@@ -172,6 +185,10 @@
   margin-bottom: 40px;
   /*padding-bottom: 40px;*/
   border-bottom: 1px solid #333;
+}
+
+:global(.dark) .contentHeader {
+  border-bottom-color: #4a5568;
 }
 
 .topHeader {

--- a/src/app/blog/[category]/[post-name]/markdown-styles.css
+++ b/src/app/blog/[category]/[post-name]/markdown-styles.css
@@ -63,3 +63,92 @@
   width: auto;
   height: auto;
 }
+
+/* Markdown element styles for dark mode support */
+.md-heading {
+  color: #111;
+}
+
+.dark .md-heading {
+  color: #e5e7eb;
+}
+
+.md-link {
+  color: #3498db;
+}
+
+.dark .md-link {
+  color: #60a5fa;
+}
+
+.md-strong {
+  background: linear-gradient(to top, #fff3b9 50%, transparent 60%);
+}
+
+.dark .md-strong {
+  background: linear-gradient(to top, rgba(202, 138, 4, 0.3) 50%, transparent 60%);
+}
+
+.md-blockquote {
+  color: #555;
+  border-left: 4px solid #ccc;
+  background-color: #f9f9f9;
+}
+
+.dark .md-blockquote {
+  color: #b0b0b0;
+  border-left-color: #555;
+  background-color: #1e2028;
+}
+
+.md-thead {
+  background-color: #f8f9fa;
+}
+
+.dark .md-thead {
+  background-color: #1e2028;
+}
+
+.md-th {
+  border: 1px solid #dee2e6;
+  background-color: #f8f9fa;
+}
+
+.dark .md-th {
+  border-color: #374151;
+  background-color: #1e2028;
+}
+
+.md-td {
+  border: 1px solid #dee2e6;
+}
+
+.dark .md-td {
+  border-color: #374151;
+}
+
+.md-tr {
+  border-bottom: 1px solid #dee2e6;
+}
+
+.dark .md-tr {
+  border-bottom-color: #374151;
+}
+
+/* Dark mode overrides for markdown-body */
+.dark .markdown-body a {
+  color: #60a5fa;
+}
+
+.dark .markdown-body hr {
+  background-color: #374151;
+}
+
+.dark .markdown-body blockquote {
+  color: #9ca3af;
+  border-left-color: #4b5563;
+}
+
+.dark .markdown-body code {
+  background-color: rgba(255, 255, 255, 0.1);
+}

--- a/src/app/blog/[category]/[post-name]/postMarkdown.tsx
+++ b/src/app/blog/[category]/[post-name]/postMarkdown.tsx
@@ -3,30 +3,19 @@
 import ReactMarkdown from 'react-markdown';
 import Image from 'next/image';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
-import { oneDark } from 'react-syntax-highlighter/dist/cjs/styles/prism';
+import {
+  oneLight,
+  oneDark,
+} from 'react-syntax-highlighter/dist/cjs/styles/prism';
 import remarkGfm from 'remark-gfm';
 import rehypeRaw from 'rehype-raw';
 import React from 'react';
+import { useTheme } from 'next-themes';
 
 const getHeadingText = (node: any) => {
   return node!!.children[0] && 'value' in node!!.children[0]
     ? (node!!.children[0] as any).value
     : '';
-};
-
-const CodeBlock: React.FC<{ language: string; value: string }> = ({
-  language,
-  value,
-}) => {
-  return (
-    <SyntaxHighlighter
-      language={language}
-      style={oneDark}
-      className="language-bash hljs"
-    >
-      {value}
-    </SyntaxHighlighter>
-  );
 };
 
 interface Props {
@@ -40,8 +29,26 @@ interface Props {
 
 const PostMarkdown = ({ params, containerStyles }: Props) => {
   const { decodedTitle, content, date } = params;
+  const { resolvedTheme } = useTheme();
   const generateIdFromText = (text: string) => {
     return text.replace(/\s+/g, '-').toLowerCase();
+  };
+
+  const syntaxTheme = resolvedTheme === 'dark' ? oneDark : oneLight;
+
+  const CodeBlock: React.FC<{ language: string; value: string }> = ({
+    language,
+    value,
+  }) => {
+    return (
+      <SyntaxHighlighter
+        language={language}
+        style={syntaxTheme}
+        className="language-bash hljs"
+      >
+        {value}
+      </SyntaxHighlighter>
+    );
   };
 
   return (
@@ -70,8 +77,8 @@ const PostMarkdown = ({ params, containerStyles }: Props) => {
               return (
                 <h1
                   id={generateIdFromText(headingText)}
+                  className="md-heading"
                   style={{
-                    color: '#111',
                     fontSize: '2em',
                     margin: '1.5em 0 1em 0',
                   }}
@@ -84,8 +91,8 @@ const PostMarkdown = ({ params, containerStyles }: Props) => {
               return (
                 <h2
                   id={generateIdFromText(headingText)}
+                  className="md-heading"
                   style={{
-                    color: '#111',
                     fontSize: '1.7em',
                     fontWeight: '900',
                     margin: '1.5em 0 0.5em 0',
@@ -99,8 +106,8 @@ const PostMarkdown = ({ params, containerStyles }: Props) => {
               return (
                 <h3
                   id={generateIdFromText(headingText)}
+                  className="md-heading"
                   style={{
-                    color: '#111',
                     fontSize: '1.5em',
                     fontWeight: '900',
                     margin: '0.3em 0 0.5em 0',
@@ -111,8 +118,8 @@ const PostMarkdown = ({ params, containerStyles }: Props) => {
             },
             h4: ({ node, ...props }) => (
               <h4
+                className="md-heading"
                 style={{
-                  color: '#111',
                   fontSize: '1.3em',
                   fontWeight: '600',
                   margin: '1em 0 0.5em 0',
@@ -122,8 +129,8 @@ const PostMarkdown = ({ params, containerStyles }: Props) => {
             ),
             h5: ({ node, ...props }) => (
               <h5
+                className="md-heading"
                 style={{
-                  color: '#111',
                   fontSize: '1.2em',
                   fontWeight: '600',
                   margin: '1em 0 0.5em 0',
@@ -132,12 +139,15 @@ const PostMarkdown = ({ params, containerStyles }: Props) => {
               />
             ),
             h6: ({ node, ...props }) => (
-              <h6 style={{ color: '#111', fontSize: '1em' }} {...props} />
+              <h6
+                className="md-heading"
+                style={{ fontSize: '1em' }}
+                {...props}
+              />
             ),
             ol: ({ node, ...props }) => (
               <ol
                 style={{
-                  color: '#111',
                   marginLeft: '1.2em',
                   listStyleType: 'decimal',
                 }}
@@ -147,7 +157,6 @@ const PostMarkdown = ({ params, containerStyles }: Props) => {
             li: ({ node, ...props }) => (
               <li
                 style={{
-                  color: '#111',
                   marginLeft: '0.5em',
                   fontSize: '0.95em',
                   lineHeight: '1.9em',
@@ -158,7 +167,6 @@ const PostMarkdown = ({ params, containerStyles }: Props) => {
             ul: ({ node, ...props }) => (
               <ul
                 style={{
-                  color: '#111',
                   marginLeft: '0.5em',
                   listStyleType: 'disc',
                 }}
@@ -167,11 +175,10 @@ const PostMarkdown = ({ params, containerStyles }: Props) => {
             ),
             strong: ({ node, ...props }) => (
               <strong
+                className="md-strong"
                 style={{
                   fontSize: '1em',
                   fontWeight: '600',
-                  background:
-                    'linear-gradient(to top, #fff3b9 50%, transparent 60%)',
                 }}
                 {...props}
               />
@@ -187,7 +194,7 @@ const PostMarkdown = ({ params, containerStyles }: Props) => {
               />
             ),
             a: ({ href, ...props }) => (
-              <a href={href} style={{ color: '#3498db' }} {...props} />
+              <a href={href} className="md-link" {...props} />
             ),
             br: ({ node, ...props }) => <br {...props} />,
             img: ({ src, alt }) => {
@@ -215,11 +222,9 @@ const PostMarkdown = ({ params, containerStyles }: Props) => {
             },
             blockquote: ({ node, ...props }) => (
               <blockquote
+                className="md-blockquote"
                 style={{
-                  color: '#555',
                   padding: '0.7em 1em 0.7em 1em',
-                  borderLeft: '4px solid #ccc',
-                  backgroundColor: '#f9f9f9',
                   margin: '1em 0',
                 }}
                 {...props}
@@ -242,6 +247,7 @@ const PostMarkdown = ({ params, containerStyles }: Props) => {
             },
             table: ({ node, ...props }) => (
               <table
+                className="md-table"
                 style={{
                   borderCollapse: 'collapse',
                   width: '100%',
@@ -252,29 +258,23 @@ const PostMarkdown = ({ params, containerStyles }: Props) => {
               />
             ),
             thead: ({ node, ...props }) => (
-              <thead
-                style={{
-                  backgroundColor: '#f8f9fa',
-                }}
-                {...props}
-              />
+              <thead className="md-thead" {...props} />
             ),
             th: ({ node, ...props }) => (
               <th
+                className="md-th"
                 style={{
-                  border: '1px solid #dee2e6',
                   padding: '0.75rem',
                   textAlign: 'left',
                   fontWeight: '600',
-                  backgroundColor: '#f8f9fa',
                 }}
                 {...props}
               />
             ),
             td: ({ node, ...props }) => (
               <td
+                className="md-td"
                 style={{
-                  border: '1px solid #dee2e6',
                   padding: '0.75rem',
                 }}
                 {...props}
@@ -284,12 +284,7 @@ const PostMarkdown = ({ params, containerStyles }: Props) => {
               <tbody {...props} />
             ),
             tr: ({ node, ...props }) => (
-              <tr
-                style={{
-                  borderBottom: '1px solid #dee2e6',
-                }}
-                {...props}
-              />
+              <tr className="md-tr" {...props} />
             ),
           }}
         >

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -82,6 +82,11 @@
   font-weight: 600;
 }
 
+.dark .code-inline {
+  color: #f0a0bb;
+  background: #3d1f2a;
+}
+
 code {
   font-family: 'Source Code Pro', monospace; /* 코드 블록 폰트 */
 }
@@ -104,6 +109,19 @@ pre {
 
 .language-bash.hljs .hljs-string {
   color: #50a14f;
+}
+
+.dark .language-bash.hljs {
+  color: #abb2bf;
+  background: #282c34;
+}
+
+.dark .language-bash.hljs .hljs-built_in {
+  color: #56b6c2;
+}
+
+.dark .language-bash.hljs .hljs-string {
+  color: #98c379;
 }
 
 /* Blog Page Layout Wrapper */
@@ -144,6 +162,11 @@ pre {
   border: 1px solid #e5e7eb;
 }
 
+.dark .toc-container {
+  background-color: #1e2028;
+  border-color: #374151;
+}
+
 .toc-title {
   font-size: 0.875rem;
   font-weight: 600;
@@ -151,6 +174,10 @@ pre {
   letter-spacing: 0.05em;
   color: #6b7280;
   margin-bottom: 1rem;
+}
+
+.dark .toc-title {
+  color: #9ca3af;
 }
 
 .toc-list {
@@ -189,6 +216,14 @@ pre {
 .toc-link:hover {
   color: #1f2937;
   /*background-color: #e5e7eb;*/
+}
+
+.dark .toc-link {
+  color: #9ca3af;
+}
+
+.dark .toc-link:hover {
+  color: #e5e7eb;
 }
 
 .toc-link.active {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ import { Header } from '@/layouts/Header';
 import { Bottom } from '@/layouts/Bottom';
 import styles from '@/app/blog/TeamPage.module.css';
 import { useSelectedLayoutSegments } from 'next/navigation';
+import { ThemeProvider } from 'next-themes';
 
 const ibmPlexSansKr = IBM_Plex_Sans_KR({
   weight: ['400', '500', '600', '700'],
@@ -38,13 +39,15 @@ export default function RootLayout({
         <link rel="icon" href="/src/app/favicon.ico" />
       </Head>
       <body>
-        <div className={styles.container}>
-          <main className={styles.main}>
-            <Header />
-            {children}
-            <Bottom />
-          </main>
-        </div>
+        <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+          <div className={styles.container}>
+            <main className={styles.main}>
+              <Header />
+              {children}
+              <Bottom />
+            </main>
+          </div>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/components/ui/CardSection.tsx
+++ b/src/components/ui/CardSection.tsx
@@ -15,21 +15,21 @@ const CardSection = ({posts}: { posts: CardInterface[] }) => {
                     >
                         {/* 카드 스타일링 */}
                         <div key={post.title}
-                             className="p-2 max-md:p-4 rounded-lg border md:border-0 border-gray-200 hover:shadow-lg transition-shadow duration-300 bg-white">
+                             className="p-2 max-md:p-4 rounded-lg border md:border-0 border-gray-200 dark:border-gray-700 hover:shadow-lg transition-shadow duration-300 bg-white dark:bg-background">
                             <div>
                                 <div className="flex flex-col sm:flex-row items-start sm:items-center gap-2">
     <span className="max-md:text-lg sm:text-xl font-semibold break-words">
         ⚡️ {post.title}
     </span>
-                                    <div className="text-[13px] text-pink-500 bg-pink-50 rounded-lg px-2 py-1">
+                                    <div className="text-[13px] text-pink-500 dark:text-[#f975a2] bg-pink-50 dark:bg-[rgb(41,38,40)] rounded-lg px-2 py-1">
                                         {post.category}
                                     </div>
-                                    <p className="text-sm sm:text-base text-gray-600 line-clamp-2 sm:ml-auto">
+                                    <p className="text-sm sm:text-base text-gray-600 dark:text-[rgb(191,191,191)] line-clamp-2 sm:ml-auto">
                                         {post.date.toLocaleDateString()}
                                     </p>
                                 </div>
                                 <div className="mt-3">
-                                    <p className="text-sm sm:text-base text-gray-600 line-clamp-2">
+                                    <p className="text-sm sm:text-base text-gray-600 dark:text-[rgb(191,191,191)] line-clamp-2">
                                         💭 {post.summary}
                                     </p>
                                 </div>

--- a/src/layouts/Header.tsx
+++ b/src/layouts/Header.tsx
@@ -1,14 +1,25 @@
 'use client';
 
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import styles from '@/app/blog/TeamPage.module.css';
 import Link from 'next/link';
-import { Github, Linkedin } from 'lucide-react';
+import { Github, Linkedin, Sun, Moon } from 'lucide-react';
 import { usePathname } from 'next/navigation';
 import { github, iconSize, linkedIn } from '@/lib/constant';
+import { useTheme } from 'next-themes';
 
 export const Header = () => {
   const pathname = usePathname();
+  const { resolvedTheme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const toggleTheme = () => {
+    setTheme(resolvedTheme === 'dark' ? 'light' : 'dark');
+  };
 
   return (
     <div className={`${styles.header} font-[var(--font-ibm-plex-kr)]`}>
@@ -32,7 +43,18 @@ export const Header = () => {
             About
           </Link>
         </nav>
-        <div className="flex text-xl mr-1">
+        <div className="flex text-xl mr-1 items-center">
+          <button
+            onClick={toggleTheme}
+            className="mr-4 p-1 rounded-md hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
+            aria-label="Toggle dark mode"
+          >
+            {mounted && (resolvedTheme === 'dark' ? (
+              <Sun size={iconSize} />
+            ) : (
+              <Moon size={iconSize} />
+            ))}
+          </button>
           <a href={github} className="mr-4">
             <Github size={iconSize} />
           </a>


### PR DESCRIPTION
## Summary
- Add `next-themes` for class-based dark mode toggling with system preference detection and localStorage persistence
- Add sun/moon toggle button in the header (left of GitHub icon)
- Replace hardcoded light-only colors with dark-aware CSS classes across all pages: blog list, blog post, about, header, footer, TOC sidebar

## Test plan
- [ ] Run `npm run dev` and verify the blog loads normally in light mode
- [ ] Click the dark mode toggle icon — page should switch to dark theme
- [ ] Refresh the page — theme preference should persist
- [ ] Check `/blog` page: card backgrounds, category badges, date/summary text are readable
- [ ] Check `/blog/[category]/[post-name]` pages: headings, code blocks, TOC sidebar, blockquotes, tables are readable
- [ ] Check `/about` page: body text is readable in dark mode
- [ ] Check header/footer: toggle icon, nav links, borders, and social icons are visible in both modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)